### PR TITLE
Forward arguments to foundryup

### DIFF
--- a/src/foundry/install.sh
+++ b/src/foundry/install.sh
@@ -26,11 +26,12 @@ echo "Installing 'foundryup'"
 curl -L https://foundry.paradigm.xyz \
 	| FOUNDRY_DIR="${ROOT}" PATH="${BIN}:${PATH}" bash
 
+VAR_AT='$@'
 cat > /usr/local/bin/foundryup << EOF
 #!/bin/sh
 export FOUNDRY_DIR="${ROOT}"
 export PATH="${BIN}:\${PATH}"
-/opt/foundry/bin/foundryup
+/opt/foundry/bin/foundryup "${VAR_AT}"
 EOF
 chmod +x /usr/local/bin/foundryup
 

--- a/src/foundry/install.sh
+++ b/src/foundry/install.sh
@@ -26,12 +26,11 @@ echo "Installing 'foundryup'"
 curl -L https://foundry.paradigm.xyz \
 	| FOUNDRY_DIR="${ROOT}" PATH="${BIN}:${PATH}" bash
 
-VAR_AT='$@'
 cat > /usr/local/bin/foundryup << EOF
 #!/bin/sh
 export FOUNDRY_DIR="${ROOT}"
 export PATH="${BIN}:\${PATH}"
-/opt/foundry/bin/foundryup "${VAR_AT}"
+/opt/foundry/bin/foundryup "\$@"
 EOF
 chmod +x /usr/local/bin/foundryup
 


### PR DESCRIPTION
I wanted to install a specific version of Foundry in a devcontainer and I noticed that even just `foundryup --help` wasn't working as expected: its execution would just trigger the installation process. This is the case because `foundryup` is just a wrapper script around the actual `foundryup` binary.

These changes make all arguments to the wrapper script be forwarded to the binary.

### How to test

<details><summary>Try to execute the relevant snippet</summary>

```sh
#!/bin/sh
set -e

ROOT="/opt/foundry"
BIN="${ROOT}/bin"
VAR_AT='$@'
cat > $(which foundryup) << EOF
#!/bin/sh
export FOUNDRY_DIR="${ROOT}"
export PATH="${BIN}:\${PATH}"
/opt/foundry/bin/foundryup "${VAR_AT}"
EOF
```
</details>

<details><summary>Observe that the output is as expected</summary>

```sh
$ cat $(which foundryup)
#!/bin/sh
export FOUNDRY_DIR="/opt/foundry"
export PATH="/opt/foundry/bin:${PATH}"
/opt/foundry/bin/foundryup "$@"
```
</details>

<details><summary>Try to run `foundryup --help` with this new file on a devcontainer</summary>

```
$ foundryup --help
The installer for Foundry.

Update or revert to a specific Foundry version with ease.

By default, the latest nightly version is installed from built binaries.

USAGE:
    foundryup <OPTIONS>

OPTIONS:
    -h, --help      Print help information
    -v, --version   Install a specific version from built binaries
    -b, --branch    Build and install a specific branch
    -P, --pr        Build and install a specific Pull Request
    -C, --commit    Build and install a specific commit
    -r, --repo      Build and install from a remote GitHub repo (uses default branch if no other options are set)
    -p, --path      Build and install a local repository
    -j, --jobs      Number of CPUs to use for building Foundry (default: all CPUs)
    --arch          Install a specific architecture (supports amd64 and arm64)
    --platform      Install a specific platform (supports win32, linux, and darwin)
```
</details>